### PR TITLE
CI - Test input variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  repository:
+    runs-on: ubuntu-latest
+    name: Test `repository`
+
+    steps:
+    - name: Checkout this repository
+      uses: actions/checkout@v2
+
+    - name: Build and install 'good' test package
+      uses: ./
+      with:
+        repository: CasperWA/check-sdist-action
+        branch: CI-test_good_package
+
+  repository_token:
+    runs-on: ubuntu-latest
+    name: Test `repository` and `token`
+
+    steps:
+    - name: Checkout this repository
+      uses: actions/checkout@v2
+
+    - name: Build and install 'good' test package (using GITHUB_TOKEN)
+      uses: ./
+      with:
+        repository: CasperWA/check-sdist-action
+        branch: CI-test_good_package
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+  fail_bad_package:
+    runs-on: ubuntu-latest
+    name: Test action fails for 'bad' package
+
+    steps:
+    - name: Checkout this repository
+      uses: actions/checkout@v2
+
+    - name: Build and install 'bad' test package
+      id: action
+      continue-on-error: true
+      uses: ./
+      with:
+        repository: CasperWA/check-sdist-action
+        branch: CI-test_bad_package
+
+    - name: This runs ONLY if the action doesn't fail as expected
+      if: steps.action.outcome != 'failure' || steps.action.conclusion != 'success'
+      run: |
+          echo "Outcome: ${{ steps.action.outcome }} (not 'failure'), Conclusion: ${{ steps.action.conclusion }} (not 'success')"
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN apk add --no-cache git \
     && python -m pip install -U pip \
     && pip install -U setuptools
 
-COPY entrypoint.sh .
+COPY entrypoint.sh ./
 
-ENTRYPOINT [ "entrypoint.sh" ]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This very simple action will build a source distribution via `python setup.py sd
 There are two ways to use this action:
 
 1. First use the [`actions/checkout`](https://github.com/marketplace/actions/checkout) action to checkout your local repository, or
-2. Use the `repository` (and possibly `token`) inputs to specify any repository.
+2. Use the `repository` (and possibly `token` and `branch`) inputs to specify any repository.
 
 Concerning the second option, the token might be needed if the chosen repository is private.
 For more information about creating a personal access token (PAT) see [here](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token).
@@ -36,6 +36,7 @@ jobs:
       uses: CasperWA/check-sdist-action@v1
       with:
         repository: octocat/Spoon-Knife
+        branch: develop
         token: ${{ secrets.MY_PAT }}
 ```
 
@@ -46,6 +47,7 @@ jobs:
 | Name | Description | Default |
 |:---:|:---|:---:|
 | `repository` | Repository for which to check building and installation of the source distribution.<br>Must be a GitHub repository and the value should be of the form `<owner>/<repository>` (see example under [Usage](#Usage)).<br>If not specified, the repository in the current working directory will be used (use [`actions/checkout`](https://github.com/marketplace/actions/checkout)). | '' |
+| `branch` | Branch in `repository`, for which to check building and installation of the source distribution.<br>If not specified, the default branch is used. | '' |
 | `token` | Token with which to retrieve `repository`.<br>Used for authentication. See [Usage](#Usage) for information about a personal access token (PAT). | '' |
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "Repository for which to check building and installation of the source distribution."
     required: false
     default: ""
+  branch:
+    description: "Branch in `repository`, for which to check building and installation of the source distribution."
+    required: false
+    default: ""
   token:
     description: "Token with which to retrieve `repository`."
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,12 @@ if [ -n "${INPUT_REPOSITORY}" ]; then
         echo "Retrieving ${INPUT_REPOSITORY} (without a token) ... DONE!"
     fi
     cd target_repo
+
+    if [ -n "${INPUT_BRANCH}" ]; then
+        echo "Checking out the '${INPUT_BRANCH}' branch ..."
+        git checkout -f ${INPUT_BRANCH}
+        echo "Checking out the '${INPUT_BRANCH}' branch ... DONE!"
+    fi
 fi
 
 # Build source distribution


### PR DESCRIPTION
~Use `CasperWA/push-protected` as a test Python repository.~
This repository will be used with the special branches [`CI-test_bad_package`](https://github.com/CasperWA/check-sdist-action/tree/CI-test_bad_package) and [`CI-test_good_package`](https://github.com/CasperWA/check-sdist-action/tree/CI-test_good_package).