### PR TITLE
New release workflow to update vMAJOR tag

### DIFF
--- a/.github/static/major_version_tag_msg.txt
+++ b/.github/static/major_version_tag_msg.txt
@@ -1,0 +1,3 @@
+vMAJOR
+
+Tag pointing to the latest vMAJOR.x.y version.

--- a/.github/static/release_tag_msg.txt
+++ b/.github/static/release_tag_msg.txt
@@ -1,0 +1,3 @@
+TAG_NAME
+
+This tag was created using the publish GitHub Actions workflow.

--- a/.github/static/update_version.sh
+++ b/.github/static/update_version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+echo -e "\n### Setting commit user ###"
+git config --local user.email "casper+github@welzel.nu"
+git config --local user.name "Casper Welzel Andersen"
+
+echo -e "\n### Update version in README if needed ###"
+MAJOR_VERSION=$( echo ${GITHUB_REF#refs/tags/v} | cut -d "." -f 1 )
+sed -i -r "s|check-sdist-action@v[0-9]+|check-sdist-action@v${MAJOR_VERSION}|g" README.md
+git add README.md
+
+if [ -n "$(git status --porcelain --untracked-files=no --ignored=no)" ]; then
+    echo -e "\n### Commit update ###"
+    git commit -m "Update README with v${MAJOR_VERSION}"
+
+    echo -e "\n### Update new full version (v<MAJOR>.<MINOR>.<PATCH>) tag ###"
+    TAG_MSG=.github/static/release_tag_msg.txt
+    sed -i "s|TAG_NAME|${GITHUB_REF#refs/tags/}|g" "${TAG_MSG}"
+    git tag -af -F "${TAG_MSG}" ${GITHUB_REF#refs/tags/}
+fi
+
+echo -e "\n### Update v<MAJOR> tag ###"
+TAG_MSG=.github/static/major_version_tag_msg.txt
+sed -i "s|MAJOR|${MAJOR_VERSION}|g" "${TAG_MSG}"
+
+git tag -af -F "${TAG_MSG}" v${MAJOR_VERSION}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release - updating vMAJOR tag
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'CasperWA/check-sdist-action' && startsWith(github.ref, 'refs/tags/v')
+    env:
+      PUBLISH_UPDATE_BRANCH: main
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Update tags (and possibly the README)
+      run: .github/static/update_version.sh
+
+    - name: Push updates to '${{ env.PUBLISH_UPDATE_BRANCH }}'
+      uses: ./
+      with:
+        token: ${{ secrets.RELEASE_PAT }}
+        branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        force: true
+        tags: true


### PR DESCRIPTION
The workflow will update README as well with new vMAJOR if MAJOR version is changed.

If a new MAJOR version is created, the workflow will create a new commit as well and update the newly created full version tag to this commit.